### PR TITLE
Enable Drag Drop File From Email Body

### DIFF
--- a/OutlookFileDrag/DragDropHook.cs
+++ b/OutlookFileDrag/DragDropHook.cs
@@ -26,7 +26,7 @@ namespace OutlookFileDrag
             try
             {
                 log.Debug("Drag started");
-                if (!DataObjectHelper.GetDataPresent(pDataObj, "FileGroupDescriptorW"))
+                if (DataObjectHelper.GetFilenames(pDataObj) == null)
                 {
                     log.Debug("No virtual files found -- continuing original drag");
                     return NativeMethods.DoDragDrop(pDataObj, pDropSource, dwOKEffects, pdwEffect);


### PR DESCRIPTION
- Before only attachment from attachment bar can be drag drop, this enable drag drop from email content body.