### PR TITLE
Embedded attachment from RTF message not handled properly

### DIFF
--- a/OutlookFileDrag/DragDropHook.cs
+++ b/OutlookFileDrag/DragDropHook.cs
@@ -79,7 +79,7 @@ namespace OutlookFileDrag
             try
             {
                 log.Info("Drag started");
-                if (!DataObjectHelper.GetDataPresent(pDataObj, "FileGroupDescriptorW"))
+                if (!DataObjectHelper.GetDataPresent(pDataObj, "FileGroupDescriptorW") && !DataObjectHelper.GetDataPresent(pDataObj, "FileGroupDescriptor"))
                 {
                     log.Info("No virtual files found -- continuing original drag");
                     return NativeMethods.DoDragDrop(pDataObj, pDropSource, dwOKEffects, out pdwEffect);


### PR DESCRIPTION
# Problem

If an attachment is not a regular attachment, but embedded inside an RTF mail, it is not handled properly.

# Steps to reproduce

Create a new message, set the format to RTF and drag any document (e.g. DOCX or PDF) in the body:

![grafik](https://user-images.githubusercontent.com/164357/72354879-bc6f2500-36e6-11ea-9f7b-fa6bfd9af027.png)

Save or send the message, then try to drag the embedded document somewhere.

# Expected result

OutlookFileDrag adds CF_HDROP for the dragged document

# Actual Result

OutlookFileDrag ignores the dragged document ("No virtual files found")

# Reason

When dragging embedded attachments from RTF messages, there is no `FileGroupDescriptorW`, but only a `FileGroupDescriptor`. `DataObjectHelper.GetFilenames()` can actually handle this (through `GetFilenamesAnsi`), but we never reach that point because the if clause in DragDropHook.cs line 82 only searches for `FileGroupDescriptorW`.

# Solution

Apply the patch to check for `FileGroupDescriptor`, too

