### PR TITLE
fix data corruption when FILEGROUPDESCRIPTOR is larger than 4k

### DIFF
--- a/OutlookFileDrag/DataObjectHelper.cs
+++ b/OutlookFileDrag/DataObjectHelper.cs
@@ -392,7 +392,7 @@ namespace OutlookFileDrag
                 {
                     //Copy buffer length or remaining length, whichever is smaller
                     bytesToCopy = Math.Min(buffer.Length, length - offset);
-                    Marshal.Copy(source, buffer, 0, bytesToCopy);
+                    Marshal.Copy(source + offset, buffer, 0, bytesToCopy);
                     stream.Write(buffer, 0, bytesToCopy);
                 }
             }


### PR DESCRIPTION
Due to missing offset in Marshal.Copy, ReadHGlobalIntoStream replicates the first 4k of the hGlobal, leading to truncated filenames when dragging a lot of mails (10 or more).